### PR TITLE
Update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @db87 @duncanmmacleod @freise
+* @danielbrown2 @duncanmmacleod @freise

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@db87](https://github.com/db87/)
+* [@danielbrown2](https://github.com/danielbrown2/)
 * [@duncanmmacleod](https://github.com/duncanmmacleod/)
 * [@freise](https://github.com/freise/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,6 +85,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - db87
+    - danielbrown2
     - duncanmmacleod
     - freise


### PR DESCRIPTION
This PR updates the maintainer names. The initial feedstock build failed because it triggered before a dependency was built, so we don't need to bump any build numbers.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
